### PR TITLE
SVD_rebuild bug fix for comp_slice

### DIFF
--- a/pycroscopy/core/viz/plot_utils.py
+++ b/pycroscopy/core/viz/plot_utils.py
@@ -587,9 +587,15 @@ def plot_map(axis, img, show_xy_ticks=True, show_cbar=True, x_vec=None, y_vec=No
 
         x_ticks = np.linspace(0, img.shape[1] - 1, num_ticks, dtype=int)
         if x_vec is not None:
-            if not isinstance(x_vec, (np.ndarray, list, tuple, range)) or len(x_vec) != img.shape[1]:
-                raise ValueError('x_vec should be array-like with shape equal to the second axis of img')
-            x_tick_labs = [str(np.round(x_vec[ind], 2)) for ind in x_ticks]
+            if isinstance(x_vec, (int,float)):
+                if x_vec > 0.01:
+                    x_tick_labs = [str(np.round(ind* x_vec/img.shape[1],2)) for ind in x_ticks]
+                else:
+                    x_tick_labs = ['{0:.2e}'.format(ind* x_vec/img.shape[1]) for ind in x_ticks]
+            else:
+                if not isinstance(x_vec, (np.ndarray, list, tuple, range)) or len(x_vec) != img.shape[1]:
+                    raise ValueError('x_vec should be array-like with shape equal to the second axis of img or img_size')
+                x_tick_labs = [str(np.round(x_vec[ind], 2)) for ind in x_ticks]
         else:
             x_tick_labs = [str(ind) for ind in x_ticks]
 
@@ -598,11 +604,15 @@ def plot_map(axis, img, show_xy_ticks=True, show_cbar=True, x_vec=None, y_vec=No
 
         y_ticks = np.linspace(0, img.shape[0] - 1, num_ticks, dtype=int)
         if y_vec is not None:
-            if not isinstance(y_vec, (np.ndarray, list, tuple, range)) or len(y_vec) != img.shape[0]:
-                raise ValueError('y_vec should be array-like with shape equal to the first axis of img')
-            y_tick_labs = [str(np.round(y_vec[ind], 2)) for ind in y_ticks]
-        else:
-            y_tick_labs = [str(ind) for ind in y_ticks]
+            if isinstance(y_vec, (int,float)):
+                if y_vec > 0.01:
+                    y_tick_labs = [str(np.round(ind* y_vec/img.shape[1],2)) for ind in y_ticks]
+                else:
+                    y_tick_labs = ['{0:.2e}'.format(ind* y_vec/img.shape[1]) for ind in y_ticks]
+            else:
+                if not isinstance(y_vec, (np.ndarray, list, tuple, range)) or len(y_vec) != img.shape[0]:
+                    raise ValueError('y_vec should be array-like with shape equal to the first axis of img')
+                y_tick_labs = [str(np.round(y_vec[ind], 2)) for ind in y_ticks]
 
         axis.set_yticks(y_ticks)
         axis.set_yticklabels(y_tick_labs)

--- a/pycroscopy/processing/svd_utils.py
+++ b/pycroscopy/processing/svd_utils.py
@@ -293,7 +293,7 @@ def rebuild_svd(h5_main, components=None, cores=None, max_RAM_mb=1024):
     '''
     Calculate the size of a single batch that will fit in the available memory
     '''
-    n_comps = h5_S[comp_slice].size
+    n_comps = h5_S[list(comp_slice)].size
     mem_per_pix = (h5_U.dtype.itemsize + h5_V.dtype.itemsize * h5_V.shape[1]) * n_comps
     fixed_mem = h5_main.size * h5_main.dtype.itemsize
 

--- a/pycroscopy/processing/svd_utils.py
+++ b/pycroscopy/processing/svd_utils.py
@@ -259,6 +259,8 @@ def rebuild_svd(h5_main, components=None, cores=None, max_RAM_mb=1024):
 
     """
     comp_slice, num_comps = get_component_slice(components, total_components=h5_main.shape[1])
+    if isinstance(comp_slice, np.ndarray):
+        comp_slice = list(comp_slice)
     dset_name = h5_main.name.split('/')[-1]
 
     # Ensuring that at least one core is available for use / 2 cores are available for other use
@@ -293,7 +295,7 @@ def rebuild_svd(h5_main, components=None, cores=None, max_RAM_mb=1024):
     '''
     Calculate the size of a single batch that will fit in the available memory
     '''
-    n_comps = h5_S[list(comp_slice)].size
+    n_comps = h5_S[comp_slice].size
     mem_per_pix = (h5_U.dtype.itemsize + h5_V.dtype.itemsize * h5_V.shape[1]) * n_comps
     fixed_mem = h5_main.size * h5_main.dtype.itemsize
 


### PR DESCRIPTION
Found that if you have an arbitrary list of slices (e.g. [0,1,4]) h5Py was throwing an error during svd_rebuild. Looking it up this is maybe a known issue in h5Py using ndarray. 