### PR TITLE
Updates to PiFM/Igor translator

### DIFF
--- a/pycroscopy/io/translators/__init__.py
+++ b/pycroscopy/io/translators/__init__.py
@@ -36,9 +36,11 @@ from .beps_data_generator import FakeBEPSGenerator
 from .labview_h5_patcher import LabViewH5Patcher
 from .nanonis import NanonisTranslator
 from .image import ImageTranslator
+from .pifm import PiFMTranslator
 
 __all__ = ['BEodfTranslator', 'BEPSndfTranslator', 'BEodfRelaxationTranslator',
            'GIVTranslator', 'GLineTranslator', 'GTuneTranslator', 'GDMTranslator', 'PtychographyTranslator',
            'SporcTranslator', 'MovieTranslator', 'IgorIBWTranslator',
            'OneViewTranslator', 'NDataTranslator', 'FakeBEPSGenerator',
-           'LabViewH5Patcher', 'TRKPFMTranslator', 'BrukerAFMTranslator', 'ImageTranslator']
+           'LabViewH5Patcher', 'TRKPFMTranslator', 'BrukerAFMTranslator', 'ImageTranslator',
+           'PiFMTranslator', 'NanonisTranslator']

--- a/pycroscopy/io/translators/igor_ibw.py
+++ b/pycroscopy/io/translators/igor_ibw.py
@@ -59,7 +59,7 @@ class IgorIBWTranslator(Translator):
         else:
             h5_path = append_path
             if not path.exists(append_path):
-                raise Exception('Improper file')
+                raise Exception('File does not exist. Check pathname.')
             h5_file = h5py.File(h5_path, 'r+')
         
 

--- a/pycroscopy/io/translators/igor_ibw.py
+++ b/pycroscopy/io/translators/igor_ibw.py
@@ -13,7 +13,7 @@ from igor import binarywave as bw
 
 from pyUSID.io.translator import Translator, \
     generate_dummy_main_parms  # Because this class extends the abstract Translator class
-from pyUSID.io.write_utils import VALUES_DTYPE, Dimension, clean_string_att
+from pyUSID.io.write_utils import VALUES_DTYPE, Dimension
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset, write_simple_attrs, write_ind_val_dsets
 
 
@@ -23,7 +23,7 @@ class IgorIBWTranslator(Translator):
     """
 
     def translate(self, file_path, verbose=False, append_path='', 
-                  grp_name='', parm_encoding='utf-8'):
+                  grp_name='Measurement', parm_encoding='utf-8'):
         """
         Translates the provided file to .h5
 
@@ -34,7 +34,7 @@ class IgorIBWTranslator(Translator):
         verbose : Boolean (Optional)
             Whether or not to show  print statements for debugging
         append_path : string (Optional)
-            h5_file to add these data to
+            h5_file to add these data to, must be a path to the h5_file on disk
         grp_name : string (Optional)
             Change from default "Measurement" name to something specific
         parm_encoding : str, optional
@@ -123,10 +123,7 @@ class IgorIBWTranslator(Translator):
             spec_desc = Dimension('Z', 'm', spec_data)
 
         # Create measurement group
-        if not grp_name:
-            meas_grp = create_indexed_group(h5_file, 'Measurement')
-        else:
-            meas_grp = create_indexed_group(h5_file, grp_name)
+        meas_grp = create_indexed_group(h5_file, grp_name)
 
         # Write file and measurement level parameters
         global_parms = generate_dummy_main_parms()

--- a/pycroscopy/io/translators/igor_ibw.py
+++ b/pycroscopy/io/translators/igor_ibw.py
@@ -22,7 +22,8 @@ class IgorIBWTranslator(Translator):
     Translates Igor Binary Wave (.ibw) files containing images or force curves to .h5
     """
 
-    def translate(self, file_path, verbose=False, append_path='', parm_encoding='utf-8'):
+    def translate(self, file_path, verbose=False, append_path='', 
+                  grp_name='', parm_encoding='utf-8'):
         """
         Translates the provided file to .h5
 
@@ -34,6 +35,8 @@ class IgorIBWTranslator(Translator):
             Whether or not to show  print statements for debugging
         append_path : string (Optional)
             h5_file to add these data to
+        grp_name : string (Optional)
+            Change from default "Measurement" name to something specific
         parm_encoding : str, optional
             Codec to be used to decode the bytestrings into Python strings if needed.
             Default 'utf-8'
@@ -55,6 +58,8 @@ class IgorIBWTranslator(Translator):
             h5_file = h5py.File(h5_path, 'w')
         else:
             h5_path = append_path
+            if not path.exists(append_path):
+                raise Exception('Improper file')
             h5_file = h5py.File(h5_path, 'r+')
         
 
@@ -118,7 +123,10 @@ class IgorIBWTranslator(Translator):
             spec_desc = Dimension('Z', 'm', spec_data)
 
         # Create measurement group
-        meas_grp = create_indexed_group(h5_file, 'Measurement')
+        if not grp_name:
+            meas_grp = create_indexed_group(h5_file, 'Measurement')
+        else:
+            meas_grp = create_indexed_group(h5_file, grp_name)
 
         # Write file and measurement level parameters
         global_parms = generate_dummy_main_parms()

--- a/pycroscopy/io/translators/igor_ibw.py
+++ b/pycroscopy/io/translators/igor_ibw.py
@@ -22,7 +22,7 @@ class IgorIBWTranslator(Translator):
     Translates Igor Binary Wave (.ibw) files containing images or force curves to .h5
     """
 
-    def translate(self, file_path, verbose=False, parm_encoding='utf-8'):
+    def translate(self, file_path, verbose=False, append_path='', parm_encoding='utf-8'):
         """
         Translates the provided file to .h5
 
@@ -32,6 +32,8 @@ class IgorIBWTranslator(Translator):
             Absolute path of the .ibw file
         verbose : Boolean (Optional)
             Whether or not to show  print statements for debugging
+        append_path : string (Optional)
+            h5_file to add these data to
         parm_encoding : str, optional
             Codec to be used to decode the bytestrings into Python strings if needed.
             Default 'utf-8'
@@ -45,11 +47,16 @@ class IgorIBWTranslator(Translator):
         # Prepare the .h5 file:
         folder_path, base_name = path.split(file_path)
         base_name = base_name[:-4]
-        h5_path = path.join(folder_path, base_name + '.h5')
-        if path.exists(h5_path):
-            remove(h5_path)
-
-        h5_file = h5py.File(h5_path, 'w')
+        
+        if not append_path:
+            h5_path = path.join(folder_path, base_name + '.h5')
+            if path.exists(h5_path):
+                remove(h5_path)
+            h5_file = h5py.File(h5_path, 'w')
+        else:
+            h5_path = append_path
+            h5_file = h5py.File(h5_path, 'r+')
+        
 
         # Load the ibw file first
         ibw_obj = bw.load(file_path)

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -12,7 +12,7 @@ class PiFMTranslator(Translator):
     structure.
     """
 
-    def translate(self, path, append_path='', grp_name=''):
+    def translate(self, path, append_path='', grp_name='Measurement'):
         """
         Parameters
         ----------
@@ -21,7 +21,7 @@ class PiFMTranslator(Translator):
         verbose : Boolean (Optional)
             Whether or not to show  print statements for debugging
         append_path : string (Optional)
-            h5_file to add these data to
+            h5_file to add these data to, must be a path to the h5_file on disk
         parm_encoding : str, optional
             Codec to be used to decode the bytestrings into Python strings if needed.
             Default 'utf-8'
@@ -184,7 +184,7 @@ class PiFMTranslator(Translator):
                     usid.write_utils.Dimension('Y', self.params_dictionary['YPhysUnit'].replace('\xb5', 'u'), self.y_len)]
         self.pos_ind, self.pos_val, self.pos_dims = pos_ind, pos_val, pos_dims
 
-    def create_hdf5_file(self, append_path='', grp_name=''):
+    def create_hdf5_file(self, append_path='', grp_name='Measurement'):
         if not append_path:
             h5_path = os.path.join(self.directory, self.basename.replace('.txt', '.h5'))
             if os.path.exists(h5_path):
@@ -196,10 +196,7 @@ class PiFMTranslator(Translator):
         else:
             self.h5_f = h5py.File(append_path, mode='r+')
 
-        if not grp_name:
-            self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, 'Measurement_')
-        else:
-            self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, grp_name)
+        self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, grp_name)
         
         usid.hdf_utils.write_simple_attrs(self.h5_meas_grp, self.params_dictionary)
 

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -3,6 +3,8 @@ import numpy as np
 from pyUSID.io.translator import Translator
 from pyUSID.io import write_utils
 from pyUSID import USIDataset
+import pyUSID as usid
+import h5py
 
 class PiFMTranslator(Translator):
     """

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -11,13 +11,46 @@ class PiFMTranslator(Translator):
     Class that writes images, spectrograms, point spectra and associated ancillary data sets to h5 file in pyUSID data
     structure.
     """
-    def __init__(self, path=None):
-        self.path = path
-#        super(HyperspectralTranslator, self).__init__(*args, **kwargs)
 
-    def get_path(self):
+    def translate(self, path, append_path=''):
+        """
+        Parameters
+        ----------
+        file_path : String / unicode
+            Absolute path of the .ibw file
+        verbose : Boolean (Optional)
+            Whether or not to show  print statements for debugging
+        append_path : string (Optional)
+            h5_file to add these data to
+        parm_encoding : str, optional
+            Codec to be used to decode the bytestrings into Python strings if needed.
+            Default 'utf-8'
+
+        Returns
+        -------
+        h5_path : String / unicode
+            Absolute path of the .h5 file
+        """
+        self.get_path(path)
+        self.read_anfatec_params()
+        self.read_file_desc()
+        self.read_spectrograms()
+        self.read_imgs()
+        self.read_spectra()
+        self.make_pos_vals_inds_dims()
+        self.create_hdf5_file(append_path)
+        self.write_spectrograms()
+        self.write_images()
+        self.write_spectra()
+        
+        return self.h5_f
+
+
+    def get_path(self, path):
         """writes full path, directory, and file name as attributes to class"""
         # get paths/get params dictionary, img/spectrogram/spectrum descriptions
+        
+        self.path = path
         full_path = os.path.realpath(self.path)
         directory = os.path.dirname(full_path)
         # file name
@@ -151,16 +184,23 @@ class PiFMTranslator(Translator):
                     usid.write_utils.Dimension('Y', self.params_dictionary['YPhysUnit'].replace('\xb5', 'u'), self.y_len)]
         self.pos_ind, self.pos_val, self.pos_dims = pos_ind, pos_val, pos_dims
 
-    def create_hdf5_file(self):
-        h5_path = os.path.join(self.directory, self.basename.replace('.txt', '.h5'))
-        try:
-            self.h5_f = h5py.File(h5_path, mode='w')
-        #if file already exists. (maybe there is a better way to check for this)
-        except OSError:
-            self.h5_f = h5py.File(h5_path, mode='r+')
+    def create_hdf5_file(self, append_path=''):
+        if not append_path:
+            h5_path = os.path.join(self.directory, self.basename.replace('.txt', '.h5'))
+            if os.path.exists(h5_path):
+                self.h5_f = h5py.File(h5_path, mode='w')
+            #if file already exists. (maybe there is a better way to check for this)
+            else:
+                self.h5_f = h5py.File(h5_path, mode='r+')
+
+        else:
+            self.h5_f = h5py.File(append_path, mode='r+')
+
         self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, 'Measurement_')
         usid.hdf_utils.write_simple_attrs(self.h5_meas_grp, self.params_dictionary)
 
+        return
+    
     def write_spectrograms(self):
         if bool(self.spectrogram_desc):
             for spectrogram_f, descriptors in self.spectrogram_desc.items():
@@ -290,19 +330,3 @@ class PiFMTranslator(Translator):
                                                                             'YLoc': descriptors[1]})
                 h5_raw[:, :] = self.spectra[spec_f].reshape(h5_raw.shape)
 
-    def translate(self):
-        """
-        :return: h5 file.
-        """
-        self.get_path()
-        self.read_anfatec_params()
-        self.read_file_desc()
-        self.read_spectrograms()
-        self.read_imgs()
-        self.read_spectra()
-        self.make_pos_vals_inds_dims()
-        self.create_hdf5_file()
-        self.write_spectrograms()
-        self.write_images()
-        self.write_spectra()
-        return self.h5_f

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -12,7 +12,7 @@ class PiFMTranslator(Translator):
     structure.
     """
 
-    def translate(self, path, append_path=''):
+    def translate(self, path, append_path='', grp_name=''):
         """
         Parameters
         ----------
@@ -38,7 +38,7 @@ class PiFMTranslator(Translator):
         self.read_imgs()
         self.read_spectra()
         self.make_pos_vals_inds_dims()
-        self.create_hdf5_file(append_path)
+        self.create_hdf5_file(append_path, grp_name)
         self.write_spectrograms()
         self.write_images()
         self.write_spectra()
@@ -184,7 +184,7 @@ class PiFMTranslator(Translator):
                     usid.write_utils.Dimension('Y', self.params_dictionary['YPhysUnit'].replace('\xb5', 'u'), self.y_len)]
         self.pos_ind, self.pos_val, self.pos_dims = pos_ind, pos_val, pos_dims
 
-    def create_hdf5_file(self, append_path=''):
+    def create_hdf5_file(self, append_path='', grp_name=''):
         if not append_path:
             h5_path = os.path.join(self.directory, self.basename.replace('.txt', '.h5'))
             if os.path.exists(h5_path):
@@ -196,7 +196,11 @@ class PiFMTranslator(Translator):
         else:
             self.h5_f = h5py.File(append_path, mode='r+')
 
-        self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, 'Measurement_')
+        if not grp_name:
+            self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, 'Measurement_')
+        else:
+            self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, grp_name)
+        
         usid.hdf_utils.write_simple_attrs(self.h5_meas_grp, self.params_dictionary)
 
         return

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -188,10 +188,10 @@ class PiFMTranslator(Translator):
         if not append_path:
             h5_path = os.path.join(self.directory, self.basename.replace('.txt', '.h5'))
             if os.path.exists(h5_path):
-                self.h5_f = h5py.File(h5_path, mode='w')
+                raise FileExistsError
             #if file already exists. (maybe there is a better way to check for this)
             else:
-                self.h5_f = h5py.File(h5_path, mode='r+')
+                self.h5_f = h5py.File(h5_path, mode='w')
 
         else:
             self.h5_f = h5py.File(append_path, mode='r+')

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -194,6 +194,8 @@ class PiFMTranslator(Translator):
                 self.h5_f = h5py.File(h5_path, mode='w')
 
         else:
+            if not os.path.exists(append_path):
+                raise Exception('File does not exist. Check pathname.')
             self.h5_f = h5py.File(append_path, mode='r+')
 
         self.h5_meas_grp = usid.hdf_utils.create_indexed_group(self.h5_f, grp_name)


### PR DESCRIPTION
Some logic and bug fixes for these translators. PiFM reorganized and slightly rewritten to match logical layout of Igor translator.

These also add two new options for ease of use in data science applications.
1) adding a grp_name parameters so you can rename from the default (and usually uninformative) 'Measurement' name
2) adding an append_path that lets you add the translated file to an existing *.h5 file. 