### PR TITLE
added check for dimensionality of spectroscopic values in read_spectrograms to accomodate for data acquired with polarizer.

### DIFF
--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -140,7 +140,14 @@ class PiFMTranslator(Translator):
         for file_name, descriptors in self.spectrogram_desc.items():
             #load and save spectroscopic values
             spec_vals_i = np.loadtxt(os.path.join(self.directory, file_name.strip('.int') + 'Wavelengths.txt'))
-            spectrogram_spec_vals[file_name] = spec_vals_i
+            #if true, data is acquired with polarizer, with an attenuation data column
+            if np.array(spec_vals_i).ndim == 2:
+                spectrogram_spec_vals[file_name] = spec_vals_i[:, 0]
+                attenuation = {}
+                attenuation[file_name] = spec_vals_i[:, 1]
+                self.attenuation = attenuation
+            else:
+                spectrogram_spec_vals[file_name] = spec_vals_i
             #load and save spectrograms
             spectrogram_i = np.fromfile(os.path.join(self.directory, file_name), dtype='i4')
             spectrograms[file_name] = np.zeros((self.x_len, self.y_len, len(spec_vals_i)))


### PR DESCRIPTION
Previously, read_spectrograms did not take into account attenuation column in wavelength txt file associated with hyperspectral image 