### PR TITLE
sidpy/pyUSID import error fixes

### DIFF
--- a/pycroscopy/io/translators/AR_hdf5.py
+++ b/pycroscopy/io/translators/AR_hdf5.py
@@ -10,7 +10,7 @@ import os
 import sys
 import re  # used to get note values
 
-from pyUSID.io import Dimension
+from pyUSID import Dimension
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs, print_tree, get_attributes
 #from sidpy.io.write_utils import make_indices_matrix

--- a/pycroscopy/io/translators/AR_hdf5.py
+++ b/pycroscopy/io/translators/AR_hdf5.py
@@ -10,9 +10,10 @@ import os
 import sys
 import re  # used to get note values
 
+from pyUSID.io import Dimension
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs, print_tree, get_attributes
-from pyUSID.io.write_utils import Dimension, make_indices_matrix
+#from sidpy.io.write_utils import make_indices_matrix
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset
 
 if sys.version_info.major == 3:

--- a/pycroscopy/io/translators/bruker_afm.py
+++ b/pycroscopy/io/translators/bruker_afm.py
@@ -14,7 +14,7 @@ import h5py
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from pyUSID.io.write_utils import Dimension
+from pyUSID.io import Dimension
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset, \
     write_ind_val_dsets
 from .df_utils.base_utils import read_binary_data

--- a/pycroscopy/io/translators/bruker_afm.py
+++ b/pycroscopy/io/translators/bruker_afm.py
@@ -14,7 +14,7 @@ import h5py
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from pyUSID.io import Dimension
+from pyUSID import Dimension
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset, \
     write_ind_val_dsets
 from .df_utils.base_utils import read_binary_data

--- a/pycroscopy/io/translators/nanonis.py
+++ b/pycroscopy/io/translators/nanonis.py
@@ -13,7 +13,7 @@ from sidpy.hdf.hdf_utils import write_simple_attrs
 
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset,\
     write_ind_val_dsets
-from pyUSID.io.write_utils import Dimension
+from pyUSID.io import Dimension
 
 from .df_utils.nanonis_utils import read_nanonis_file
 # TODO: Adopt any missing features from https://github.com/paruch-group/distortcorrect/blob/master/afm/filereader/nanonisFileReader.py

--- a/pycroscopy/io/translators/nanonis.py
+++ b/pycroscopy/io/translators/nanonis.py
@@ -13,7 +13,7 @@ from sidpy.hdf.hdf_utils import write_simple_attrs
 
 from pyUSID.io.hdf_utils import create_indexed_group, write_main_dataset,\
     write_ind_val_dsets
-from pyUSID.io import Dimension
+from pyUSID import Dimension
 
 from .df_utils.nanonis_utils import read_nanonis_file
 # TODO: Adopt any missing features from https://github.com/paruch-group/distortcorrect/blob/master/afm/filereader/nanonisFileReader.py

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -5,7 +5,8 @@ import h5py
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from pyUSID.io.write_utils import Dimension, build_ind_val_matrices
+from sidpy import Dimension
+from pyUSID.io.anc_build_utils import build_ind_val_matrices
 from pyUSID.io.hdf_utils import write_main_dataset, create_indexed_group, get_all_main
 from pyUSID import USIDataset
 

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -337,6 +337,7 @@ class PiFMTranslator(Translator):
                                                               np.array([float(descriptors[1])]))]
                 #write data to a channel in the measurement group
                 spec_i_ch = usid.hdf_utils.create_indexed_group(self.h5_meas_grp, 'Spectrum_')
+                print(descriptors)
                 h5_raw = usid.hdf_utils.write_main_dataset(spec_i_ch,  # parent HDF5 group
                                                            (1, len(self.spectra_spec_vals[spec_f])),  # shape of Main dataset
                                                            'Raw_Spectrum',
@@ -348,8 +349,8 @@ class PiFMTranslator(Translator):
                                                            pos_dims=spec_i_pos_dims, spec_dims=spec_i_spec_dims,
                                                            # Spectroscopic dimensions
                                                            dtype=np.float32,  # data type / precision
-                                                           main_dset_attrs={'XLoc': descriptors[0],
-                                                                            'YLoc': descriptors[1]})
+                                                           main_dset_attrs={'XLoc': descriptors[1],
+                                                                            'YLoc': descriptors[2]})
                 h5_raw[:, :] = self.spectra[spec_f].reshape(h5_raw.shape)
 
     def write_ps_spectra(self):

--- a/pycroscopy/io/translators/pifm.py
+++ b/pycroscopy/io/translators/pifm.py
@@ -5,7 +5,7 @@ import h5py
 from sidpy.sid import Translator
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from sidpy import Dimension
+from pyUSID import Dimension
 from pyUSID.io.anc_build_utils import build_ind_val_matrices
 from pyUSID.io.hdf_utils import write_main_dataset, create_indexed_group, get_all_main
 from pyUSID import USIDataset

--- a/pycroscopy/io/write_utils.py
+++ b/pycroscopy/io/write_utils.py
@@ -14,7 +14,7 @@ import h5py
 import numpy as np
 
 from .virtual_data import VirtualDataset
-from pyUSID.io.write_utils import INDICES_DTYPE, VALUES_DTYPE, Dimension, build_ind_val_matrices, get_aux_dset_slicing
+from pyUSID.io.anc_build_utils import INDICES_DTYPE, VALUES_DTYPE, Dimension, build_ind_val_matrices, get_aux_dset_slicing
 
 if sys.version_info.major == 3:
     unicode = str

--- a/pycroscopy/processing/cluster.py
+++ b/pycroscopy/processing/cluster.py
@@ -24,7 +24,7 @@ from pyUSID.processing.process import Process
 from pyUSID.io.hdf_utils import reshape_to_n_dims, create_results_group, \
     write_main_dataset, write_ind_val_dsets
 from pyUSID import USIDataset
-from pyUSID.io.write_utils import Dimension
+from sidpy import Dimension
 
 from .proc_utils import get_component_slice
 

--- a/pycroscopy/processing/cluster.py
+++ b/pycroscopy/processing/cluster.py
@@ -24,7 +24,7 @@ from pyUSID.processing.process import Process
 from pyUSID.io.hdf_utils import reshape_to_n_dims, create_results_group, \
     write_main_dataset, write_ind_val_dsets
 from pyUSID import USIDataset
-from sidpy import Dimension
+from pyUSID import Dimension
 
 from .proc_utils import get_component_slice
 

--- a/pycroscopy/processing/decomposition.py
+++ b/pycroscopy/processing/decomposition.py
@@ -21,7 +21,7 @@ from sidpy.hdf.dtype_utils import check_dtype, stack_real_to_target_dtype
 from pyUSID.processing.process import Process
 from pyUSID.io.hdf_utils import reshape_to_n_dims, create_results_group, \
     write_main_dataset
-from pyUSID.io.write_utils import Dimension
+from pyUSID.io import Dimension
 from pyUSID import USIDataset
 
 

--- a/pycroscopy/processing/gmode_utils.py
+++ b/pycroscopy/processing/gmode_utils.py
@@ -22,7 +22,7 @@ from sidpy.viz.plot_utils import set_tick_font_size, plot_curves
 from pyUSID import USIDataset
 from pyUSID.io.hdf_utils import check_if_main, write_main_dataset, \
     create_results_group
-from pyUSID.io.write_utils import Dimension
+from sidpy import Dimension
 
 if sys.version_info.major == 3:
     unicode = str

--- a/pycroscopy/processing/gmode_utils.py
+++ b/pycroscopy/processing/gmode_utils.py
@@ -22,7 +22,7 @@ from sidpy.viz.plot_utils import set_tick_font_size, plot_curves
 from pyUSID import USIDataset
 from pyUSID.io.hdf_utils import check_if_main, write_main_dataset, \
     create_results_group
-from sidpy import Dimension
+from pyUSID import Dimension
 
 if sys.version_info.major == 3:
     unicode = str

--- a/pycroscopy/processing/image_processing.py
+++ b/pycroscopy/processing/image_processing.py
@@ -19,12 +19,12 @@ from scipy.signal import blackman
 from sklearn.utils import gen_batches
 
 from sidpy.proc.comp_utils import get_available_memory
-from sidpy.hdf.hdf_utils import get_h5_obj_refs, link_h5_objects_as_attrs
+from sidpy.hdf.hdf_utils import get_h5_obj_refs, link_h5_objects_as_attrs, copy_attributes
 
 from pyUSID import USIDataset
-from pyUSID.io.hdf_utils import copy_attributes, find_results_groups, \
+from pyUSID.io.hdf_utils import find_results_groups, \
     link_as_main, check_for_old
-from pyUSID.io.write_utils import make_indices_matrix, get_aux_dset_slicing, \
+from pyUSID.io.anc_build_utils import make_indices_matrix, get_aux_dset_slicing, \
     INDICES_DTYPE, VALUES_DTYPE, calc_chunks
 
 from ..io.hdf_writer import HDFwriter

--- a/pycroscopy/processing/signal_filter.py
+++ b/pycroscopy/processing/signal_filter.py
@@ -17,7 +17,7 @@ from collections import Iterable
 from sidpy.proc.comp_utils import parallel_compute
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from pyUSID.io import Dimension
+from pyUSID import Dimension
 from pyUSID.io.hdf_utils import create_results_group, write_main_dataset, create_empty_dataset, \
     write_ind_val_dsets
 from pyUSID.processing.process import Process

--- a/pycroscopy/processing/signal_filter.py
+++ b/pycroscopy/processing/signal_filter.py
@@ -17,7 +17,7 @@ from collections import Iterable
 from sidpy.proc.comp_utils import parallel_compute
 from sidpy.hdf.hdf_utils import write_simple_attrs
 
-from pyUSID.io.write_utils import Dimension
+from pyUSID.io import Dimension
 from pyUSID.io.hdf_utils import create_results_group, write_main_dataset, create_empty_dataset, \
     write_ind_val_dsets
 from pyUSID.processing.process import Process

--- a/pycroscopy/processing/svd_utils.py
+++ b/pycroscopy/processing/svd_utils.py
@@ -15,17 +15,18 @@ from sklearn.utils import gen_batches
 from sklearn.utils.extmath import randomized_svd
 
 from sidpy.hdf.reg_ref import get_indices_for_region_ref, create_region_reference
-from sidpy.hdf.hdf_utils import get_attr, write_simple_attrs
+from sidpy.hdf.hdf_utils import get_attr, write_simple_attrs, copy_attributes
 from sidpy.proc.comp_utils import get_available_memory
 from sidpy.base.string_utils import format_time
 from sidpy.hdf.dtype_utils import check_dtype, stack_real_to_target_dtype
 
 from pyUSID.processing.process import Process
 from .proc_utils import get_component_slice
-from pyUSID.io.hdf_utils import find_results_groups, copy_attributes, \
+from pyUSID.io.hdf_utils import find_results_groups,  \
     reshape_to_n_dims, write_main_dataset, create_results_group, \
     create_indexed_group, find_dataset
-from pyUSID.io.write_utils import Dimension, calc_chunks
+from pyUSID import Dimension
+from pyUSID.io.anc_build_utils import calc_chunks
 from pyUSID import USIDataset
 
 import h5py


### PR DESCRIPTION
Some import fixes for changes to pyUSID and sidpy, e.g. ```pyUSID.io.write_utils``` is now ```pyUSID.io.anc_build_utils``` and ```copy_attributes``` moved. 