### PR TITLE
fix: in sidpy, o_image.get_image_dims(return_axis=True) is depreciated -> use o_image.dim_0.slope

### DIFF
--- a/pycroscopy/image/image_clean.py
+++ b/pycroscopy/image/image_clean.py
@@ -90,8 +90,8 @@ def decon_lr(o_image, resolution=0.1,  verbose=False):
     if len(o_image) < 1:
         return o_image
 
-    image_dimensions = o_image.dim_0.slope #o_image.get_image_dims(return_axis=True)
-    scale_x = image_dimensions[0].slope
+    image_dimensions = o_image.get_image_dims(return_axis=True)
+    scale_x = o_image.dim_0.slope #image_dimensions[0].slope
     gauss_diameter = resolution/scale_x
     probe = make_gauss(o_image.shape[0], o_image.shape[1], gauss_diameter)
 

--- a/pycroscopy/image/image_clean.py
+++ b/pycroscopy/image/image_clean.py
@@ -90,7 +90,7 @@ def decon_lr(o_image, resolution=0.1,  verbose=False):
     if len(o_image) < 1:
         return o_image
 
-    image_dimensions = o_image.get_image_dims(return_axis=True)
+    image_dimensions = o_image.dim_0.slope #o_image.get_image_dims(return_axis=True)
     scale_x = image_dimensions[0].slope
     gauss_diameter = resolution/scale_x
     probe = make_gauss(o_image.shape[0], o_image.shape[1], gauss_diameter)


### PR DESCRIPTION
Because atom_stats test was failing -> https://github.com/pycroscopy/atomStats/blob/8cb0e5d080342bd5bf254fa0d26a29451cb486e4/tests/test.py#L50